### PR TITLE
add filters to clmask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- ability to filter examples out during training of `CLMaskPretrainer`
+- ability to transform examples during training of `CLMaskPretrainer`
+
 ## [0.1.2] - 2021-06-30
 ### Added
 - `Shelf` implementation and tests

--- a/examples/base_pretraining_example.py
+++ b/examples/base_pretraining_example.py
@@ -37,6 +37,13 @@ ap.add_argument(
     default=256,
     type=int,
 )
+ap.add_argument(
+    "--epochs",
+    help="number of epochs to train",
+    dest="epochs",
+    default=100,
+    type=int,
+)
 args = ap.parse_args()
 
 mlflow.log_params(vars(args))
@@ -80,7 +87,7 @@ callbacks = [
     CLMaskPretrainerEvaluationCallback(dataset, bp),
 ]
 
-bp.model.fit(gen, steps_per_epoch=5000, epochs=500, callbacks=callbacks)
+bp.model.fit(gen, steps_per_epoch=5000, epochs=args.epochs, callbacks=callbacks)
 x, y = next(gen)
 print(bp.evaluate_prediction(x, bp.model.predict(x), prep))
 


### PR DESCRIPTION
optional list of functions to filter out examples with the `CLMaskPretrainer`.
optional list of transform functions for `CLMaskPretrainer`

For example, remove any wikipedia page that contains a certain string, or clip the bottom of wikipedia articles with long `Category:` sections.